### PR TITLE
replace setup-output with GITHUB_OUTPUT env var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,4 +21,4 @@ echo "running entrypoint command(s)"
 
 response=$(sh -c " $INPUT_COMMAND")
 
-echo "::set-output name=response::$response"
+echo "response=$response" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Why this change?

Due to the deprecation of set-output env var , receiving the warning and needs to be replaced with $GITHUB_OUTPUT env var as per the guideline.

``` The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ ```